### PR TITLE
SagaKeeper introduced

### DIFF
--- a/A2v10.ProcS.Interfaces/ISagaKeeper.cs
+++ b/A2v10.ProcS.Interfaces/ISagaKeeper.cs
@@ -1,0 +1,18 @@
+﻿// Copyright © 2020 Alex Kukhtin. All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+
+namespace A2v10.ProcS.Interfaces
+{
+	public interface ISagaKeeperKey : IEquatable<ISagaKeeperKey>
+	{
+		Type SagaType { get; }
+		ICorrelationId CorrelationId { get; }
+	}
+
+	public interface ISagaKeeper {
+		ISaga GetSagaForMessage(IMessage message, out ISagaKeeperKey key, out bool isNew);
+		void SagaUpdate(ISaga saga, ISagaKeeperKey key);
+	}
+}

--- a/A2v10.ProcS.Interfaces/IServiceBus.cs
+++ b/A2v10.ProcS.Interfaces/IServiceBus.cs
@@ -5,15 +5,22 @@ using System.Threading.Tasks;
 
 namespace A2v10.ProcS.Interfaces
 {
+	public interface ICorrelationId : IEquatable<ICorrelationId>
+	{
+		
+	}
+
+
 	public interface IMessage
 	{
-		String CorrelationId { get; }
+		ICorrelationId CorrelationId { get; }
 	}
 
 	public interface ISaga
 	{
 		Boolean IsComplete { get; }
-		Task<String> Handle(IHandleContext context, IMessage message);
+		ICorrelationId CorrelationId { get; }
+		Task Handle(IHandleContext context, IMessage message);
 	}
 
 

--- a/A2v10.ProcS.Run/Program.cs
+++ b/A2v10.ProcS.Run/Program.cs
@@ -11,7 +11,7 @@ namespace A2v10.ProcS.Run
 	{
 		static void Main(String[] args)
 		{
-			var bus = new ServiceBus(null);
+			var bus = new ServiceBus(new InMemorySagaKeeper(), null);
 			var engine = new WorkflowEngine(null, null, bus);
 
 			while (true)

--- a/A2v10.ProcS.Tests/DelayAction.cs
+++ b/A2v10.ProcS.Tests/DelayAction.cs
@@ -14,7 +14,8 @@ namespace A2v10.ProcS.Tests
 		public async Task SimpleRun()
 		{
 			var storage = new FakeStorage();
-			var bus = new ServiceBus(storage);
+			var keeper = new InMemorySagaKeeper();
+			var bus = new ServiceBus(keeper, storage);
 			var stm = await storage.WorkflowFromStorage(new Identity("delay.json")) as StateMachine;
 
 			Assert.AreEqual("S1", stm.InitialState);

--- a/A2v10.ProcS.Tests/IdleActions.cs
+++ b/A2v10.ProcS.Tests/IdleActions.cs
@@ -16,12 +16,13 @@ namespace A2v10.ProcS.Tests
 		public async Task SimpleCallApi()
 		{
 			var storage = new FakeStorage();
+			var keeper = new InMemorySagaKeeper();
 
 			var wf = await storage.WorkflowFromStorage(new Identity("callapi.json")) as StateMachine;
 			var stm = wf as StateMachine;
 			Assert.IsInstanceOfType(stm.States["S1"].OnEntry, typeof(CallHttpApi));
 
-			var bus = new ServiceBus(storage);
+			var bus = new ServiceBus(keeper, storage);
 
 			var engine = new WorkflowEngine(storage, storage, bus);
 			IInstance instance = await engine.Run(wf);

--- a/A2v10.ProcS.Tests/ScriptAction.cs
+++ b/A2v10.ProcS.Tests/ScriptAction.cs
@@ -15,7 +15,8 @@ namespace A2v10.ProcS.Tests
 		IWorkflowEngine CreateEngine()
 		{
 			var storage = new FakeStorage();
-			var bus = new ServiceBus(storage);
+			var keeper = new InMemorySagaKeeper();
+			var bus = new ServiceBus(keeper, storage);
 			return new WorkflowEngine(storage, storage, bus);
 		}
 

--- a/A2v10.ProcS.Tests/SimpleStateMachine.cs
+++ b/A2v10.ProcS.Tests/SimpleStateMachine.cs
@@ -38,10 +38,11 @@ namespace A2v10.ProcS.Tests
 		public async Task SimpleRunStateMachine()
 		{
 			var storage = new FakeStorage();
+			var keeper = new InMemorySagaKeeper();
 
 			//var stm = await storage.WorkflowFromStorage(new Identity("simple.json"));
 
-			var bus = new ServiceBus(storage);
+			var bus = new ServiceBus(keeper, storage);
 			var engine = new WorkflowEngine(storage, storage, bus);
 
 			var instance = await engine.StartWorkflow(new Identity("simple.json"));

--- a/A2v10.ProcS.Tests/SimpleStateMachine.cs
+++ b/A2v10.ProcS.Tests/SimpleStateMachine.cs
@@ -38,10 +38,11 @@ namespace A2v10.ProcS.Tests
 		public async Task SimpleRunStateMachine()
 		{
 			var storage = new FakeStorage();
+			var keeper = new InMemorySagaKeeper();
 
 			//var stm = await storage.WorkflowFromStorage(new Identity("simple.json"));
 
-			var bus = new ServiceBus(storage);
+			var bus = new ServiceBus(keeper, storage);
 
 			var engine = new WorkflowEngine(storage, storage, bus);
 

--- a/A2v10.ProcS/SagaKeeper.cs
+++ b/A2v10.ProcS/SagaKeeper.cs
@@ -1,0 +1,94 @@
+﻿// Copyright © 2020 Alex Kukhtin. All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using A2v10.ProcS.Interfaces;
+
+namespace A2v10.ProcS
+{
+	public abstract class SagaBase<CorrelationT> : ISaga where CorrelationT : IEquatable<CorrelationT>
+	{
+		public CorrelationId<CorrelationT> CorrelationId { get; } = new CorrelationId<CorrelationT>();
+
+		ICorrelationId ISaga.CorrelationId => CorrelationId;
+
+		public Boolean IsComplete { get; set; }
+		public abstract Task Handle(IHandleContext context, IMessage message);
+	}
+
+	public class InMemorySagaKeeperKey : ISagaKeeperKey
+	{
+		public Type SagaType { get; private set; }
+		public ICorrelationId CorrelationId { get; private set; }
+
+
+		public InMemorySagaKeeperKey(Type sagaType, ICorrelationId correlationId)
+		{
+			SagaType = sagaType;
+			CorrelationId = correlationId;
+		}
+
+		public InMemorySagaKeeperKey(ISaga saga)
+		{
+			SagaType = saga.GetType();
+			CorrelationId = saga.CorrelationId;
+		}
+
+		public override int GetHashCode()
+		{
+			return SagaType.GetHashCode() + 17 * (CorrelationId?.GetHashCode() ?? 0);
+		}
+
+		public override string ToString()
+		{
+			return SagaType.Name + ":" + (CorrelationId?.ToString() ?? "{null}");
+		}
+
+		public bool Equals(ISagaKeeperKey other)
+		{
+			return SagaType.Equals(other.SagaType) && CorrelationId.Equals(other.CorrelationId);
+		}
+	}
+
+	public class InMemorySagaKeeper : ISagaKeeper
+	{
+		private static readonly Dictionary<Type, Type> _messagesMap = new Dictionary<Type, Type>();
+		private readonly ConcurrentDictionary<ISagaKeeperKey, ISaga> _sagas = new ConcurrentDictionary<ISagaKeeperKey, ISaga>();
+		
+		public static void RegisterMessageType<TMessage, TSaga>() where TMessage : IMessage where TSaga : ISaga
+		{
+			_messagesMap.Add(typeof(TMessage), typeof(TSaga));
+		}
+
+		public ISaga GetSagaForMessage(IMessage message, out ISagaKeeperKey key, out bool isNew)
+		{
+			var sagaType = _messagesMap[message.GetType()];
+			key = new InMemorySagaKeeperKey(sagaType, message.CorrelationId);
+			if (message.CorrelationId != null && _sagas.TryGetValue(key, out ISaga saga))
+			{
+				isNew = false;
+				return saga;
+			}
+			else 
+			{
+				isNew = true;
+				return System.Activator.CreateInstance(sagaType) as ISaga;
+			}
+		}
+
+		public void SagaUpdate(ISaga saga, ISagaKeeperKey key)
+		{
+			if (saga.IsComplete || saga.CorrelationId == null || !saga.CorrelationId.Equals(key.CorrelationId))
+			{
+				_sagas.TryRemove(key, out ISaga removed);
+			}
+			if (!saga.IsComplete)
+			{
+				_sagas.AddOrUpdate(new InMemorySagaKeeperKey(saga), saga, (k, s) => saga);
+			}
+		}
+	}
+}

--- a/A2v10.ProcS/ServiceBus.cs
+++ b/A2v10.ProcS/ServiceBus.cs
@@ -9,28 +9,63 @@ using A2v10.ProcS.Interfaces;
 
 namespace A2v10.ProcS
 {
+	public class CorrelationId<T> : ICorrelationId, IEquatable<CorrelationId<T>> where T : IEquatable<T>
+	{
+		public T Value { get; set; }
+
+		public CorrelationId()
+		{
+			Value = default(T);
+		}
+
+		public CorrelationId(T value)
+		{
+			Value = value;
+		}
+
+		public bool Equals(ICorrelationId other)
+		{
+			var tt = other as CorrelationId<T>;
+			if (tt == null) return false;
+			return Equals(tt);
+		}
+
+		public override int GetHashCode()
+		{
+			return Value?.GetHashCode() ?? 0;
+		}
+
+		public bool Equals(CorrelationId<T> other)
+		{
+			if (Value == null) return other.Value == null;
+			return Value.Equals(other.Value);
+		}
+	}
+
+	public class MessageBase<CorrelationT> : IMessage where CorrelationT : IEquatable<CorrelationT>
+	{
+		public CorrelationId<CorrelationT> CorrelationId { get; set; } = new CorrelationId<CorrelationT>();
+
+		ICorrelationId IMessage.CorrelationId => CorrelationId;
+	}
+
 	public class ServiceBus : IServiceBus
 	{
-		private static readonly Dictionary<Type, Type> _messagesMap = new Dictionary<Type, Type>();
-		private static readonly Dictionary<Tuple<Type, String>, ISaga> _sagas = new Dictionary<Tuple<Type, String>, ISaga>();
+		private readonly ISagaKeeper _sagaKeeper;
 		ConcurrentQueue<IMessage> _messages = new ConcurrentQueue<IMessage>();
 
 
 		private readonly IInstanceStorage _instanceStorage;
 
-		public ServiceBus(IInstanceStorage instanceStorage)
+		public ServiceBus(ISagaKeeper sagaKeeper, IInstanceStorage instanceStorage)
 		{
 			_instanceStorage = instanceStorage ?? throw new ArgumentNullException(nameof(instanceStorage));
+			_sagaKeeper = sagaKeeper;
 		}
 
 		public void Send(IMessage message)
 		{
 			_messages.Enqueue(message);
-		}
-
-		public static void RegisterSaga<TStartMessage, TSaga>() where TStartMessage : IMessage where TSaga : ISaga
-		{
-			_messagesMap.Add(typeof(TStartMessage), typeof(TSaga));
 		}
 
 		public async Task Run()
@@ -41,37 +76,19 @@ namespace A2v10.ProcS
 			}
 		}
 
-		async Task ProcessMessage(IMessage message)
-		{
-			if (_messagesMap.TryGetValue(message.GetType(), out Type sagaType))
-				await ProcessMessage(sagaType, message);
-		}
-
 		IHandleContext CreateHandleContext()
 		{
 			return new HandleContext(this, _instanceStorage);
 		}
 
-		async Task ProcessMessage(Type sagaType, IMessage message)
+		async Task ProcessMessage(IMessage message)
 		{
-			var key = Tuple.Create(sagaType, message.CorrelationId);
-			if (message.CorrelationId != null && _sagas.TryGetValue(key, out ISaga saga))
-			{
-				var hc = CreateHandleContext();
-				await saga.Handle(hc, message);
-				if (saga.IsComplete)
-					_sagas.Remove(Tuple.Create(sagaType, message.CorrelationId));
-			}
-			else 
-			{
-				saga = System.Activator.CreateInstance(sagaType) as ISaga;
-				var hc = CreateHandleContext();
-				var corrId = await saga.Handle(hc, message);
-				if (corrId != null)
-				{
-					_sagas.Add(Tuple.Create(sagaType, corrId), saga);
-				}
-			}
+			var saga = _sagaKeeper.GetSagaForMessage(message, out ISagaKeeperKey key, out bool isNew);
+
+			var hc = CreateHandleContext();
+			await saga.Handle(hc, message);
+
+			_sagaKeeper.SagaUpdate(saga, key);
 		}
 	}
 }


### PR DESCRIPTION
ConcurrentQueue<IMessage> _messages в ServiceBus теперь не статическая

private static readonly Dictionary<Type, Type> _messagesMap пока ушли в SagaKeeper, в планах вынести в отдельную сущность и тоже избавиться от статики.

CorrelationId теперь дженерик объект, инкапсулирующий любой тип. В планах сделать ему явное описание поведения Singleton и PerMessage.

У Саги появилось свойство CorrelationId, Handle теперь не возвращает новое значение, а просто его меняет. С точки зрения Сага-кипера такой дизайн тоже будет удобен.

Подумать: Как хранить Тип саги во внешних хранилищах очереди, возможно хранить не тип, а какое-то имя, навешиваемое аттрибутом. Еще важный вопрос - версионирование саг.